### PR TITLE
Remove line limits

### DIFF
--- a/apic.go
+++ b/apic.go
@@ -86,6 +86,7 @@ func yaml_emitter_initialize(emitter *yaml_emitter_t) {
 		raw_buffer: make([]byte, 0, output_raw_buffer_size),
 		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
 		events:     make([]yaml_event_t, 0, initial_queue_size),
+		best_width: -1,
 	}
 }
 

--- a/apic.go
+++ b/apic.go
@@ -79,6 +79,8 @@ func yaml_parser_set_encoding(parser *yaml_parser_t, encoding yaml_encoding_t) {
 	parser.encoding = encoding
 }
 
+var disableLineWrapping = false
+
 // Create a new emitter object.
 func yaml_emitter_initialize(emitter *yaml_emitter_t) {
 	*emitter = yaml_emitter_t{
@@ -86,7 +88,9 @@ func yaml_emitter_initialize(emitter *yaml_emitter_t) {
 		raw_buffer: make([]byte, 0, output_raw_buffer_size),
 		states:     make([]yaml_emitter_state_t, 0, initial_stack_size),
 		events:     make([]yaml_event_t, 0, initial_queue_size),
-		best_width: -1,
+	}
+	if disableLineWrapping {
+		emitter.best_width = -1
 	}
 }
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -367,6 +367,11 @@ var marshalTests = []struct {
 		map[string]string{"a": "你好 #comment"},
 		"a: '你好 #comment'\n",
 	},
+	// Ensure that strings do not wrap
+	{
+		map[string]string{"a": "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 "},
+		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n",
+	},
 }
 
 func (s *S) TestMarshal(c *C) {

--- a/encode_test.go
+++ b/encode_test.go
@@ -367,11 +367,27 @@ var marshalTests = []struct {
 		map[string]string{"a": "你好 #comment"},
 		"a: '你好 #comment'\n",
 	},
-	// Ensure that strings do not wrap
-	{
-		map[string]string{"a": "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 "},
-		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n",
-	},
+}
+
+func (s *S) TestLineWrapping(c *C) {
+	var v = map[string]string{
+		"a": "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 ",
+	}
+	data, err := yaml.Marshal(v)
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals,
+		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz\n" +
+		"  ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n")
+
+	// The API does not allow this process to be reversed as it's intended
+	// for migration only. v3 drops this method and instead offers more
+	// control on a per encoding basis.
+	yaml.FutureLineWrap()
+
+	data, err = yaml.Marshal(v)
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals,
+		"a: 'abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890 '\n")
 }
 
 func (s *S) TestMarshal(c *C) {

--- a/yaml.go
+++ b/yaml.go
@@ -483,3 +483,15 @@ func isZero(v reflect.Value) bool {
 	}
 	return false
 }
+
+// FutureLineWrap globally disables line wrapping when encoding long strings.
+// This is a temporary and thus deprecated method introduced to faciliate
+// migration towards v3, which offers more control of line lengths on
+// individual encodings, and has a default matching the behavior introduced
+// by this function.
+//
+// The default formatting of v2 was erroneously changed in v2.3.0 and reverted
+// in v2.4.0, at which point this function was introduced to help migration.
+func FutureLineWrap() {
+	disableLineWrapping = true
+}


### PR DESCRIPTION
This PR pulls in 0b1645d91e851e735d3e23330303ce81f70adbe3 and 7649d4548cb53a614db133b2a8ac1f31859dda8c from the upstream repo, which collectively allow for configurable line limits.

Line limits are causing issues on in cockroachdb/cockroach when printing
out long constraints fields for zone configurations. With limits in
place, long zone configuration constraints fields will have one or more
`\n`'s added to them. To avoid this, and have the constraints field
appear as one contiguous line (regardless of its length), we remove the
line limits here.